### PR TITLE
Use Origami Image Set Tools for publishing

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   node:
     version: 6
   post:
-    - npm install -g origami-build-tools
+    - npm install -g origami-build-tools@^5
 dependencies:
   override:
     - obt install
@@ -12,3 +12,10 @@ test:
   override:
     - obt test
     - obt verify
+deployment:
+  publish-imageset:
+    tag: /v.*/
+    owner: Financial-Times
+    commands:
+      - ./node_modules/.bin/oist publish-s3 --bucket origami-imageset-data-eu --source-directory svg --scheme fticonold --scheme-version $CIRCLE_TAG
+      - ./node_modules/.bin/oist publish-s3 --bucket origami-imageset-data-us --source-directory svg --scheme fticonold --scheme-version $CIRCLE_TAG

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "o-icons",
   "private": true,
   "engines": {
-  	"node": "^4.0.0"
+    "node": "^6"
   },
   "devDependencies": {
-    "gulp": "^3.9.1"
+    "gulp": "^3.9.1",
+    "@financial-times/origami-image-set-tools": "^1.0.0"
   }
 }


### PR DESCRIPTION
We need to use OIST to publish the v4 icon set which powers the versionless `fticon` scheme in the Image Service. This won't affect `master` or v5+ releases.