### PR TITLE
Show icons in ms high contrast mode.

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -14,6 +14,7 @@
     },
     "demos": [
         {
+            "title": "Test",
             "name": "test",
             "template": "demos/src/test.mustache",
             "sass": "demos/src/demo.scss",

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -25,7 +25,8 @@
 	$scheme: "fticon-v#{$iconset-version}";
 
 	$service-url: "#{$o-icons-service-base-url}/#{$o-icons-service-version}/images/raw/#{$scheme}:#{$icon-name}";
-	$query: "?source=o-icons";
+	$source: "o-icons";
+	$query: "?source=#{$source}";
 
 	@if $color != null {
 		$color: str-slice(ie-hex-str($color), 4);
@@ -42,6 +43,14 @@
 	// Hack is documented here: http://browserhacks.com/#hack-ab1bcc7b3a6544c99260f7608f8e845e
 	// It still needs to use the build service  <-- what does this comment mean?
 	background-image: url($service-url + $query + "&format=png&width=#{$container-width}")\9;
+
+	@media screen and (-ms-high-contrast: active) {
+		background-image: url($service-url + "?source=#{$source}&tint=%23ffffff,%23ffffff&format=svg");
+	}
+
+	@media screen and (-ms-high-contrast: black-on-white) {
+		background-image: url($service-url + "?source=#{$source}&tint=%23000000,%23000000&format=svg");
+	}
 
 	// Prevents dimension styles being output by default.
 	// Resolves issue where previous component `o-ft-icons` the mixin this replaces,

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -44,6 +44,7 @@
 	// It still needs to use the build service  <-- what does this comment mean?
 	background-image: url($service-url + $query + "&format=png&width=#{$container-width}")\9;
 
+	// sass-lint:disable no-vendor-prefixes
 	@media screen and (-ms-high-contrast: active) {
 		background-image: url($service-url + "?source=#{$source}&tint=%23ffffff,%23ffffff&format=svg");
 	}
@@ -51,6 +52,7 @@
 	@media screen and (-ms-high-contrast: black-on-white) {
 		background-image: url($service-url + "?source=#{$source}&tint=%23000000,%23000000&format=svg");
 	}
+	// sass-lint:enable no-vendor-prefixes
 
 	// Prevents dimension styles being output by default.
 	// Resolves issue where previous component `o-ft-icons` the mixin this replaces,


### PR DESCRIPTION
Icons are hidden on Edge / IE with Windows high contrast mode enabled. 

This PR targets this mode with a media query and reinstates either a white or black icon.

We are unable to match the high contrast forgound colour using image service tints, and unfortunately Edge does not yet support the mask CSS property (https://developer.mozilla.org/en-US/docs/Web/CSS/mask). 😞 

Before no icons would display but now:
![screen shot 2018-03-16 at 14 05 24](https://user-images.githubusercontent.com/10405691/37525838-cc56ac2a-2925-11e8-9ede-1f9e8a345314.png)
![screen shot 2018-03-16 at 14 05 37](https://user-images.githubusercontent.com/10405691/37525839-cc78b91e-2925-11e8-9709-68cdcf5f6c9b.png)
![screen shot 2018-03-16 at 14 05 45](https://user-images.githubusercontent.com/10405691/37525840-cc99f26e-2925-11e8-9d04-379bc6d6adc6.png)
![screen shot 2018-03-16 at 14 05 54](https://user-images.githubusercontent.com/10405691/37525842-ccc22496-2925-11e8-8fcd-17e789527495.png)
