### PR TITLE
Allow an icon width/height to be passed to `oIconsGetIcon` with a

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -52,6 +52,12 @@
 	// Prevents dimension styles being output by default.
 	// Resolves issue where previous component `o-ft-icons` the mixin this replaces,
 	// dimension styles were included within the $apply-base-styles block as well.
+	@if (type-of($container-width) == 'number' and unitless($container-width)) {
+		$container-width: $container-width + 0px;
+	}
+	@if (type-of($container-height) == 'number' and unitless($container-height)) {
+		$container-height: $container-height + 0px;
+	}
 	@if ($apply-width-height == true) {
 		width: $container-width + 0px;
 		@if ($container-height == null) {


### PR DESCRIPTION
o-icons v5.11.2 was updated to allow an icon size to be defined with a unit. o-table relies on this feature but depends on o-icons at >=4.0.0 <6. If o-icons v4 is used o-table compilation will error. 

See https://github.com/Financial-Times/o-table/pull/172