### PR TITLE
Improve Build Service users custom icon documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ To add an icon apply the `o-icons-icon` class to a `span`, along with the modifi
 <span class="o-icons-icon o-icons-icon--book"></span>
 ```
 
-This will include icons with a `128px` width/height by default. Or use the [Sass](#sass) mixins to include icons of a given dimension and colour.
+This will include icons with a `128px` width/height by default.
+
+If you would like to use an icon at a different dimension or colour, use `o-icon` [Sass](#sass) mixins or request the icon from the [Image Service](https://www.ft.com/__origami/service/image/v2/docs/url-builder?url=fticon-v1%3Aarrow-down&preview=true) directly (without using o-icons at all).
 
 ## Sass
 

--- a/origami.json
+++ b/origami.json
@@ -25,7 +25,7 @@
             "template": "demos/src/icons.mustache",
             "sass": "demos/src/demo.scss",
             "data": "demos/src/data.json",
-            "description": "All icons available via o-icons."
+            "description": "o-icons provides helper Sass and some basic html classes for the fticons image set. This demo shows all icons available via o-icons. Build Service users may use the Image Service to fetch an icon svg from the fticons imageset directly. See the README for more details."
         },
         {
             "title": "Custom Icons",
@@ -33,7 +33,8 @@
             "template": "demos/src/custom-icons.mustache",
             "sass": "demos/src/demo.scss",
             "data": "demos/src/data.json",
-            "description": "Example customised icons generated using o-icons Sass."
+            "description": "This demo shows icons customised using o-icons helper Sass. Instead of using o-icons, Build Service users should use the Image Service to fetch a customised icon svg from the fticons imageset. See the README for more details.",
+            "display_html": false
         }
     ]
 }


### PR DESCRIPTION
- Add more details to the demo description and reference the README
as the demos are the first thing a user sees.
- Hide the html of the custom demo as it requires demo CSS to work.
- There's only one line about using the Image Service directly which
would be easy to miss -- expand that section under "markup" for
Build Service users.